### PR TITLE
#226 Update on item suggestion name and price deletion

### DIFF
--- a/lib/presentation/bills/new_bill/items_check_dialog.dart
+++ b/lib/presentation/bills/new_bill/items_check_dialog.dart
@@ -64,6 +64,13 @@ class _ItemsCheckDialogState extends ConsumerState<ItemsCheckDialog> {
   void _onNameDeletePressed(int index) {
     _currentNameList.removeAt(index);
 
+    // remove the price of the last row if the price is 0 and the price list is longer
+    // this makes deleting empty prices obsolete
+    if (_currentPriceList.length > _currentNameList.length &&
+        _currentPriceList.last == 0) {
+      _currentPriceList.removeLast();
+    }
+
     _history.add(_history.last.copyWith(
       nameList: List.from(_currentNameList),
     ));


### PR DESCRIPTION
We could add this behavior but this is not an important issue so we can stall it.
This PR makes the item suggestion screen more faster to handle. If a name is deleted which had no related price and only have a 0 price which task is only to make the lists equally long, this 0 price gets as well deleted.

PR #226 

I like this behavior but it is not important and we could argue about the advantages for it.