### PR TITLE
Added padding to items_check_dialog

### DIFF
--- a/lib/constants/ui_constants.dart
+++ b/lib/constants/ui_constants.dart
@@ -13,6 +13,7 @@ class Sizes {
   static const p40 = 40.0;
   static const p48 = 48.0;
   static const p64 = 64.0;
+  static const p80 = 80.0;
 }
 
 /// Constant gap widths

--- a/lib/presentation/bills/new_bill/items_check_dialog.dart
+++ b/lib/presentation/bills/new_bill/items_check_dialog.dart
@@ -228,6 +228,7 @@ class _ItemsCheckDialogState extends ConsumerState<ItemsCheckDialog> {
                         child: ReorderableListView.builder(
                           scrollController: _scrollControllerName,
                           itemCount: _currentNameList.length,
+                          padding: const EdgeInsets.only(bottom: Sizes.p80),
                           itemBuilder: (context, index) {
                             return Dismissible(
                               onDismissed: (_) => setState(
@@ -280,6 +281,7 @@ class _ItemsCheckDialogState extends ConsumerState<ItemsCheckDialog> {
                         child: ReorderableListView.builder(
                           scrollController: _scrollControllerPrice,
                           itemCount: _currentPriceList.length,
+                          padding: const EdgeInsets.only(bottom: Sizes.p80),
                           itemBuilder: (context, index) {
                             return Dismissible(
                               onDismissed: (_) => setState(


### PR DESCRIPTION
Added padding to items_check dialog in order for ios devices to move and delete last item/price in the list. Previously this would close the app or switch to different.

Need to check on ios device.

Closes #250 