### PR TITLE
292 show server status

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,7 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:split_the_bill/constants/constants.dart';
 import 'package:split_the_bill/router/router.dart';
+
+/// Provider that checks if the backend server is reachable.
+final serverStatusProvider = FutureProvider<bool>((ref) async {
+  try {
+    final response = await http.get(Uri.parse(
+        '${Constants.baseScheme}://${Constants.baseApiUrl}:${Constants.basePort}/status'));
+    return response.statusCode == 200;
+  } catch (_) {
+    return false;
+  }
+});
 
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
@@ -10,11 +23,40 @@ class MyApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     GoRouter.optionURLReflectsImperativeAPIs = true;
     final goRouter = ref.watch(goRouterProvider);
+    final serverStatus = ref.watch(serverStatusProvider);
 
     return MaterialApp.router(
       title: 'Split the Bill',
       debugShowCheckedModeBanner: false,
       routerConfig: goRouter,
+      builder: (context, child) {
+        // Add banner above all pages.
+        return Scaffold(
+          body: Column(
+            children: [
+              serverStatus.when(
+                data: (isOnline) => isOnline
+                    ? const SizedBox.shrink()
+                    : Container(
+                        width: double.infinity,
+                        color: Colors.amber,
+                        padding: const EdgeInsets.all(12),
+                        child: const Text(
+                          'Offline - Server currently unreachable',
+                          style: TextStyle(
+                              fontWeight: FontWeight.bold, color: Colors.black),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                loading: () => const SizedBox.shrink(),
+                error: (_, __) => const SizedBox.shrink(),
+              ),
+              // This expands the routed content below the banner
+              Expanded(child: child ?? const SizedBox.shrink()),
+            ],
+          ),
+        );
+      },
       theme: ThemeData(
         primaryColor: Colors.blue.shade400,
         scaffoldBackgroundColor: const Color(0xFFEFEFEF),

--- a/lib/infrastructure/http_client.dart
+++ b/lib/infrastructure/http_client.dart
@@ -29,6 +29,10 @@ class HttpClient {
         headers: _getHeaders(),
       );
 
+      // If server unreachable (502) json decode will throw an error -> unexpected character
+      if (response.statusCode == 502) {
+        throw NoInternetConnectionException();
+      }
       final data = json.decode(utf8.decode(response.bodyBytes));
 
       switch (response.statusCode) {

--- a/lib/infrastructure/http_client.dart
+++ b/lib/infrastructure/http_client.dart
@@ -68,6 +68,10 @@ class HttpClient {
         headers: mergedHeaders,
       );
 
+      // If server unreachable (502) json decode will throw an error -> unexpected character
+      if (response.statusCode == 502) {
+        throw NoInternetConnectionException();
+      }
       final data = json.decode(utf8.decode(response.bodyBytes));
 
       switch (response.statusCode) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,20 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:split_the_bill/app.dart';
 import 'package:split_the_bill/infrastructure/async_error_logger.dart';
 import 'package:split_the_bill/infrastructure/shared_preferences.dart';
+import 'package:http/http.dart' as http;
+import 'package:split_the_bill/constants/constants.dart';
+
+
+/// Check if the server is reachable by making a GET request to the /status endpoint.
+/// Returns true if the server responds with a 200 status code, false otherwise.
+Future<bool> isServerReachable() async {
+  try {
+    final response = await http.get(Uri.parse('${Constants.baseScheme}://${Constants.baseApiUrl}:${Constants.basePort}/status'));
+    return response.statusCode == 200;
+  } catch (_) {
+    return false;
+  }
+}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -20,7 +34,35 @@ void main() async {
       observers: [
         AsyncErrorLogger(),
       ],
-      child: const MyApp(),
+      // Server Status Banner
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: FutureBuilder<bool>(
+            future: isServerReachable(),
+            builder: (context, snapshot) {
+              final showBanner = snapshot.hasData && !snapshot.data!;
+              return Column(
+                children: [
+                  if (showBanner)
+                    Container(
+                      width: double.infinity,
+                      color: Colors.amber,
+                      padding: const EdgeInsets.all(12),
+                      child: const Text(
+                        'Offline - Server currently unreachable',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  // Main App Widget
+                  const Expanded(child: MyApp()),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
     ),
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:split_the_bill/app.dart';
+import 'package:split_the_bill/constants/constants.dart';
 import 'package:split_the_bill/infrastructure/async_error_logger.dart';
 import 'package:split_the_bill/infrastructure/shared_preferences.dart';
-import 'package:http/http.dart' as http;
-import 'package:split_the_bill/constants/constants.dart';
-
-
-/// Check if the server is reachable by making a GET request to the /status endpoint.
-/// Returns true if the server responds with a 200 status code, false otherwise.
-Future<bool> isServerReachable() async {
-  try {
-    final response = await http.get(Uri.parse('${Constants.baseScheme}://${Constants.baseApiUrl}:${Constants.basePort}/status'));
-    return response.statusCode == 200;
-  } catch (_) {
-    return false;
-  }
-}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -41,20 +29,9 @@ void main() async {
           body: FutureBuilder<bool>(
             future: isServerReachable(),
             builder: (context, snapshot) {
-              final showBanner = snapshot.hasData && !snapshot.data!;
               return Column(
                 children: [
-                  if (showBanner)
-                    Container(
-                      width: double.infinity,
-                      color: Colors.amber,
-                      padding: const EdgeInsets.all(12),
-                      child: const Text(
-                        'Offline - Server currently unreachable',
-                        style: TextStyle(fontWeight: FontWeight.bold),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
+                  buildServerStatusBanner(snapshot),
                   // Main App Widget
                   const Expanded(child: MyApp()),
                 ],
@@ -63,6 +40,35 @@ void main() async {
           ),
         ),
       ),
+    ),
+  );
+}
+
+/// Check if the server is reachable by making a GET request to the /status endpoint.
+/// Returns true if the server responds with a 200 status code, false otherwise.
+Future<bool> isServerReachable() async {
+  try {
+    final response = await http.get(Uri.parse(
+        '${Constants.baseScheme}://${Constants.baseApiUrl}:${Constants.basePort}/status'));
+    return response.statusCode == 200;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Builds a banner widget to indicate server status based on the snapshot.
+/// If the server is unreachable, it shows a banner; otherwise, it returns an empty widget.
+Widget buildServerStatusBanner(AsyncSnapshot<bool> snapshot) {
+  final showBanner = snapshot.hasData && !snapshot.data!;
+  if (!showBanner) return const SizedBox.shrink();
+  return Container(
+    width: double.infinity,
+    color: Colors.amber,
+    padding: const EdgeInsets.all(12),
+    child: const Text(
+      'Offline - Server currently unreachable',
+      style: TextStyle(fontWeight: FontWeight.bold),
+      textAlign: TextAlign.center,
     ),
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:split_the_bill/app.dart';
-import 'package:split_the_bill/constants/constants.dart';
 import 'package:split_the_bill/infrastructure/async_error_logger.dart';
 import 'package:split_the_bill/infrastructure/shared_preferences.dart';
 
@@ -19,56 +17,8 @@ void main() async {
       overrides: [
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
       ],
-      observers: [
-        AsyncErrorLogger(),
-      ],
-      // Server Status Banner
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        home: Scaffold(
-          body: FutureBuilder<bool>(
-            future: isServerReachable(),
-            builder: (context, snapshot) {
-              return Column(
-                children: [
-                  buildServerStatusBanner(snapshot),
-                  // Main App Widget
-                  const Expanded(child: MyApp()),
-                ],
-              );
-            },
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-/// Check if the server is reachable by making a GET request to the /status endpoint.
-/// Returns true if the server responds with a 200 status code, false otherwise.
-Future<bool> isServerReachable() async {
-  try {
-    final response = await http.get(Uri.parse(
-        '${Constants.baseScheme}://${Constants.baseApiUrl}:${Constants.basePort}/status'));
-    return response.statusCode == 200;
-  } catch (_) {
-    return false;
-  }
-}
-
-/// Builds a banner widget to indicate server status based on the snapshot.
-/// If the server is unreachable, it shows a banner; otherwise, it returns an empty widget.
-Widget buildServerStatusBanner(AsyncSnapshot<bool> snapshot) {
-  final showBanner = snapshot.hasData && !snapshot.data!;
-  if (!showBanner) return const SizedBox.shrink();
-  return Container(
-    width: double.infinity,
-    color: Colors.amber,
-    padding: const EdgeInsets.all(12),
-    child: const Text(
-      'Offline - Server currently unreachable',
-      style: TextStyle(fontWeight: FontWeight.bold),
-      textAlign: TextAlign.center,
+      observers: [AsyncErrorLogger()],
+      child: const MyApp(),
     ),
   );
 }


### PR DESCRIPTION
When starting the app, it gets checked if the server can be reached. If not a banner is displayed to the user:
<img width="525" height="590" alt="image" src="https://github.com/user-attachments/assets/512bd862-4e2e-4a55-b92c-598fab80678a" />

It is only check on startup.

+ Unexpected character error is no longer displayed if server is down -> no Internet connection gets displayed instead.

Closes #292 