### PR TITLE
Store and show groups offline

### DIFF
--- a/lib/domain/bill/bill.dart
+++ b/lib/domain/bill/bill.dart
@@ -108,6 +108,20 @@ class Bill {
     };
   }
 
+  /// Convert bills to map for offline storage in shared preferences, including all fields
+  Map<String, dynamic> toMapOffline() {
+    return {
+      'id': id,
+      'name': name,
+      'groupID': groupId,
+      'owner': owner.toMap(),
+      'date': '${date.toIso8601String().split('.')[0]}Z',
+      'items': items.map((item) => item.toMapOffline()).toList(),
+      'isViewed': isViewed,
+      'updatedAt': '${updatedAt.toIso8601String().split('.')[0]}Z'
+    };
+  }
+
   factory Bill.fromMap(Map<String, dynamic> map) {
     return Bill(
         id: map['id'] as String,

--- a/lib/domain/bill/item.dart
+++ b/lib/domain/bill/item.dart
@@ -78,6 +78,22 @@ class Item {
     return map;
   }
 
+  /// Convert items to map for offline storage in shared preferences, including all fields
+  Map<String, dynamic> toMapOffline() {
+    Map<String, dynamic> map = {
+      'id': id,
+      'name': name,
+      'price': price,
+      'contributorIDs': contributors.map((user) => user.id).toList(),
+    };
+
+    if (billId.isNotEmpty) {
+      map['billId'] = billId;
+    }
+
+    return map;
+  }
+
   factory Item.fromMap(Map<String, dynamic> map) {
     return Item(
       id: map['id'] as String,

--- a/lib/domain/group/data/group_repository.dart
+++ b/lib/domain/group/data/group_repository.dart
@@ -6,6 +6,8 @@ import 'package:split_the_bill/domain/group/group.dart';
 import 'package:split_the_bill/domain/group/group_transaction.dart';
 import 'package:split_the_bill/infrastructure/http_client.dart';
 
+import '../../../infrastructure/shared_preferences.dart';
+
 part 'group_repository.g.dart';
 
 abstract class GroupRepository {
@@ -31,5 +33,6 @@ GroupRepository groupRepository(Ref ref) {
   return RemoteGroupRepository(
     api: GroupAPI(),
     client: ref.read(httpClientProvider),
+    sharedUtility: ref.read(sharedUtilityProvider),
   );
 }

--- a/lib/domain/group/data/remote_group_repository.dart
+++ b/lib/domain/group/data/remote_group_repository.dart
@@ -3,13 +3,16 @@ import 'package:split_the_bill/domain/group/data/group_repository.dart';
 import 'package:split_the_bill/domain/group/group_transaction.dart';
 import 'package:split_the_bill/infrastructure/http_client.dart';
 
+import '../../../infrastructure/shared_preferences.dart';
 import '../group.dart';
 
 class RemoteGroupRepository extends GroupRepository {
-  RemoteGroupRepository({required this.api, required this.client});
+  RemoteGroupRepository(
+      {required this.api, required this.client, required this.sharedUtility});
 
   final GroupAPI api;
   final HttpClient client;
+  final SharedUtility sharedUtility;
 
   @override
   Future<Group> getGroup(String groupId) => client.get(
@@ -18,15 +21,23 @@ class RemoteGroupRepository extends GroupRepository {
       );
 
   @override
-  Future<List<Group>> getGroupsByUser(String userId) => client.get(
+  Future<List<Group>> getGroupsByUser(String userId) async {
+    try {
+      // get groups from server
+      final groups = await client.get(
         uri: api.getGroupsByUser(userId),
-        builder: (data) => data?.isNotEmpty == true
-            ? data
-                .map((groupData) => Group.fromMap(groupData))
-                .toList()
-                .cast<Group>()
-            : [],
+        builder: (data) {
+          if (data == null || data.isEmpty) return [];
+          return data.map((g) => Group.fromMap(g)).toList();
+        },
       );
+      sharedUtility.setGroups(groups);
+      return groups;
+    } catch (e) {
+      // load groups from shared preferences if server is down
+      return sharedUtility.getGroups();
+    }
+  }
 
   @override
   Future<Group> create(Group group) => client.post(

--- a/lib/domain/group/group.dart
+++ b/lib/domain/group/group.dart
@@ -76,6 +76,19 @@ class Group {
     };
   }
 
+  /// Convert group to map for offline storage in shared preferences, including all fields
+  Map<String, dynamic> toMapOffline() {
+    return {
+      'id': id,
+      'name': name,
+      'owner': owner.toMap(),
+      'members': members.map((m) => m.toMap()).toList(),
+      'bills': bills.map((b) => b.toMapOffline()).toList(),
+      'balance': balance,
+      'invitationID': invitationID,
+    };
+  }
+
   factory Group.fromMap(Map<String, dynamic> map) {
     return Group(
       id: map['id'] as String,

--- a/lib/domain/group/states/groups_state.dart
+++ b/lib/domain/group/states/groups_state.dart
@@ -5,7 +5,6 @@ import 'package:split_the_bill/auth/states/auth_state.dart';
 import 'package:split_the_bill/domain/group/data/group_repository.dart';
 import 'package:split_the_bill/domain/group/group.dart';
 import 'package:split_the_bill/domain/group/states/group_state.dart';
-import 'package:split_the_bill/infrastructure/shared_preferences.dart';
 
 import 'groups_transaction_state.dart';
 
@@ -22,17 +21,7 @@ class GroupsState extends _$GroupsState {
   }
 
   Future<List<Group>> _getGroupsByUser(String userId) async {
-    try {
-      // try to get groups from server
-      List<Group> groups = await _groupRepository.getGroupsByUser(userId);
-      // store groups in shared preferences
-      ref.read(sharedUtilityProvider).setGroups(groups);
-      return groups;
-    } catch (e) {
-      // load groups from shared preferences if server is down
-      final List<Group> groups = ref.read(sharedUtilityProvider).getGroups();
-      return groups;
-    }
+    return await _groupRepository.getGroupsByUser(userId);
   }
 
   Future<void> create(Group group) async {

--- a/lib/domain/group/states/groups_state.dart
+++ b/lib/domain/group/states/groups_state.dart
@@ -5,6 +5,7 @@ import 'package:split_the_bill/auth/states/auth_state.dart';
 import 'package:split_the_bill/domain/group/data/group_repository.dart';
 import 'package:split_the_bill/domain/group/group.dart';
 import 'package:split_the_bill/domain/group/states/group_state.dart';
+import 'package:split_the_bill/infrastructure/shared_preferences.dart';
 
 import 'groups_transaction_state.dart';
 
@@ -21,7 +22,17 @@ class GroupsState extends _$GroupsState {
   }
 
   Future<List<Group>> _getGroupsByUser(String userId) async {
-    return await _groupRepository.getGroupsByUser(userId);
+    try {
+      // try to get groups from server
+      List<Group> groups = await _groupRepository.getGroupsByUser(userId);
+      // store groups in shared preferences
+      ref.read(sharedUtilityProvider).setGroups(groups);
+      return groups;
+    } catch (e) {
+      // load groups from shared preferences if server is down
+      final List<Group> groups = ref.read(sharedUtilityProvider).getGroups();
+      return groups;
+    }
   }
 
   Future<void> create(Group group) async {

--- a/lib/infrastructure/shared_preferences.dart
+++ b/lib/infrastructure/shared_preferences.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:split_the_bill/domain/group/group.dart';
 
 part 'shared_preferences.g.dart';
 
@@ -42,5 +45,17 @@ class SharedUtility {
 
   void removeUser() {
     sharedPreferences.remove(_userKey);
+  }
+
+  List<Group> getGroups() {
+    final jsonString = sharedPreferences.getString('GROUPS');
+    if (jsonString == null || jsonString.isEmpty) return [];
+    final List<dynamic> list = jsonDecode(jsonString);
+    return list.map((e) => Group.fromMap(e)).toList().cast<Group>();
+  }
+
+  void setGroups(List<Group> groups) {
+    final jsonString = jsonEncode(groups.map((g) => g.toMapOffline()).toList());
+    sharedPreferences.setString('GROUPS', jsonString);
   }
 }

--- a/lib/infrastructure/shared_preferences.dart
+++ b/lib/infrastructure/shared_preferences.dart
@@ -8,6 +8,7 @@ import 'package:split_the_bill/domain/group/group.dart';
 part 'shared_preferences.g.dart';
 
 const String _userKey = 'USER';
+const String _groupsKey = 'GROUPS';
 
 /// A Riverpod provider for SharedPreferences.
 /// It throws an [UnimplementedError] to indicate that it should be overridden in the main function
@@ -48,14 +49,14 @@ class SharedUtility {
   }
 
   List<Group> getGroups() {
-    final jsonString = sharedPreferences.getString('GROUPS');
+    final jsonString = sharedPreferences.getString(_groupsKey);
     if (jsonString == null || jsonString.isEmpty) return [];
     final List<dynamic> list = jsonDecode(jsonString);
-    return list.map((e) => Group.fromMap(e)).toList().cast<Group>();
+    return list.map((e) => Group.fromMap(e)).toList();
   }
 
   void setGroups(List<Group> groups) {
     final jsonString = jsonEncode(groups.map((g) => g.toMapOffline()).toList());
-    sharedPreferences.setString('GROUPS', jsonString);
+    sharedPreferences.setString(_groupsKey, jsonString);
   }
 }


### PR DESCRIPTION
Now users can see their groups and balance even if they are offline. 
This PR was created in anticipation of longer server downtime or a permanent shutdown.

<img width="334" height="579" alt="Screenshot From 2025-09-29 13-33-41" src="https://github.com/user-attachments/assets/7721a093-5aa6-4145-be27-06c87d9f1c45" />

Closes #296 